### PR TITLE
feat: 게시글 로직 구현

### DIFF
--- a/src/main/java/goormcoder/webide/common/dto/ErrorMessage.java
+++ b/src/main/java/goormcoder/webide/common/dto/ErrorMessage.java
@@ -1,0 +1,16 @@
+package goormcoder.webide.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    MEMBER_NOT_FOUND("해당하는 사용자가 존재하지 않습니다."),
+    QUESTION_NOT_FOUND("해당하는 문제가 존재하지 않습니다."),
+    ;
+
+    private final String message;
+}

--- a/src/main/java/goormcoder/webide/common/dto/ErrorMessage.java
+++ b/src/main/java/goormcoder/webide/common/dto/ErrorMessage.java
@@ -10,6 +10,7 @@ public enum ErrorMessage {
 
     MEMBER_NOT_FOUND("해당하는 사용자가 존재하지 않습니다."),
     QUESTION_NOT_FOUND("해당하는 문제가 존재하지 않습니다."),
+    BOARD_NOT_FOUND("해당하는 게시글이 존재하지 않습니다."),
     ;
 
     private final String message;

--- a/src/main/java/goormcoder/webide/config/JpaAuditingConfig.java
+++ b/src/main/java/goormcoder/webide/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package goormcoder.webide.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing //JPA가 엔티티를 감시할 수 있게 해줌
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/goormcoder/webide/controller/BoardController.java
+++ b/src/main/java/goormcoder/webide/controller/BoardController.java
@@ -1,9 +1,11 @@
 package goormcoder.webide.controller;
 
 import goormcoder.webide.dto.request.BoardCreateDto;
+import goormcoder.webide.dto.request.BoardUpdateDto;
 import goormcoder.webide.dto.response.BoardFindAllDto;
 import goormcoder.webide.dto.response.BoardFindDto;
 import goormcoder.webide.service.BoardService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,5 +36,12 @@ public class BoardController {
     @GetMapping("/board/{boardId}")
     public ResponseEntity<BoardFindDto> getBoard(@PathVariable Long boardId) {
         return ResponseEntity.status(HttpStatus.OK).body(boardService.getBoard(boardId));
+    }
+
+    //게시글 수정
+    @PatchMapping("/board/{boardId}")
+    public ResponseEntity<?> updateBoard(@PathVariable Long boardId, @Valid @RequestBody BoardUpdateDto boardUpdateDto) {
+        boardService.updateBoard(boardId, boardUpdateDto);
+        return ResponseEntity.status(HttpStatus.OK).body("게시글 수정이 완료되었습니다.");
     }
 }

--- a/src/main/java/goormcoder/webide/controller/BoardController.java
+++ b/src/main/java/goormcoder/webide/controller/BoardController.java
@@ -1,13 +1,17 @@
 package goormcoder.webide.controller;
 
 import goormcoder.webide.dto.request.BoardCreateDto;
+import goormcoder.webide.dto.response.BoardFindAllDto;
 import goormcoder.webide.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,9 +19,16 @@ public class BoardController {
 
     private final BoardService boardService;
 
+    //게시글 등록
     @PostMapping("/board")
     public ResponseEntity<?> createBoard(@RequestBody BoardCreateDto boardCreateDto) {
         boardService.createBoard(boardCreateDto);
         return ResponseEntity.status(HttpStatus.OK).body("게시글이 생성되었습니다.");
+    }
+
+    //게시글 조회
+    @GetMapping("/board/all")
+    public ResponseEntity<List<BoardFindAllDto>> getAllBoards() {
+        return ResponseEntity.status(HttpStatus.OK).body(boardService.getAllBoards());
     }
 }

--- a/src/main/java/goormcoder/webide/controller/BoardController.java
+++ b/src/main/java/goormcoder/webide/controller/BoardController.java
@@ -2,14 +2,12 @@ package goormcoder.webide.controller;
 
 import goormcoder.webide.dto.request.BoardCreateDto;
 import goormcoder.webide.dto.response.BoardFindAllDto;
+import goormcoder.webide.dto.response.BoardFindDto;
 import goormcoder.webide.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -30,5 +28,11 @@ public class BoardController {
     @GetMapping("/board/all")
     public ResponseEntity<List<BoardFindAllDto>> getAllBoards() {
         return ResponseEntity.status(HttpStatus.OK).body(boardService.getAllBoards());
+    }
+
+    //게시글 열람
+    @GetMapping("/board/{boardId}")
+    public ResponseEntity<BoardFindDto> getBoard(@PathVariable Long boardId) {
+        return ResponseEntity.status(HttpStatus.OK).body(boardService.getBoard(boardId));
     }
 }

--- a/src/main/java/goormcoder/webide/controller/BoardController.java
+++ b/src/main/java/goormcoder/webide/controller/BoardController.java
@@ -1,0 +1,23 @@
+package goormcoder.webide.controller;
+
+import goormcoder.webide.dto.request.BoardCreateDto;
+import goormcoder.webide.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @PostMapping("/board")
+    public ResponseEntity<?> createBoard(@RequestBody BoardCreateDto boardCreateDto) {
+        boardService.createBoard(boardCreateDto);
+        return ResponseEntity.status(HttpStatus.OK).body("게시글이 생성되었습니다.");
+    }
+}

--- a/src/main/java/goormcoder/webide/controller/BoardController.java
+++ b/src/main/java/goormcoder/webide/controller/BoardController.java
@@ -21,7 +21,7 @@ public class BoardController {
 
     //게시글 등록
     @PostMapping("/board")
-    public ResponseEntity<?> createBoard(@RequestBody BoardCreateDto boardCreateDto) {
+    public ResponseEntity<?> createBoard(@Valid @RequestBody BoardCreateDto boardCreateDto) {
         boardService.createBoard(boardCreateDto);
         return ResponseEntity.status(HttpStatus.OK).body("게시글이 생성되었습니다.");
     }

--- a/src/main/java/goormcoder/webide/controller/BoardController.java
+++ b/src/main/java/goormcoder/webide/controller/BoardController.java
@@ -44,4 +44,11 @@ public class BoardController {
         boardService.updateBoard(boardId, boardUpdateDto);
         return ResponseEntity.status(HttpStatus.OK).body("게시글 수정이 완료되었습니다.");
     }
+
+    //게시글 삭제
+    @DeleteMapping("/board/{boardId}")
+    public ResponseEntity<?> deleteBoard(@PathVariable Long boardId) {
+        boardService.deleteBoard(boardId);
+        return ResponseEntity.status(HttpStatus.OK).body("게시글 삭제가 완료되었습니다.");
+    }
 }

--- a/src/main/java/goormcoder/webide/controller/MemberController.java
+++ b/src/main/java/goormcoder/webide/controller/MemberController.java
@@ -1,8 +1,9 @@
 package goormcoder.webide.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class MemberController {
-
 }

--- a/src/main/java/goormcoder/webide/domain/BaseTimeEntity.java
+++ b/src/main/java/goormcoder/webide/domain/BaseTimeEntity.java
@@ -1,0 +1,29 @@
+package goormcoder.webide.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void markAsDeleted(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+}

--- a/src/main/java/goormcoder/webide/domain/Board.java
+++ b/src/main/java/goormcoder/webide/domain/Board.java
@@ -1,0 +1,56 @@
+package goormcoder.webide.domain;
+
+import goormcoder.webide.domain.enums.BoardType;
+import goormcoder.webide.dto.request.BoardCreateDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "t_board")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Board extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_category", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "board_title", nullable = false)
+    private String title;
+
+    @Column(name = "board_content", nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quest_id")
+    private Question question;
+
+    public static Board of(final BoardCreateDto boardCreateDto, final Member member, final Question question) {
+        return Board.builder()
+                .boardType(boardCreateDto.boardType())
+                .title(boardCreateDto.title())
+                .content(boardCreateDto.content())
+                .member(member)
+                .question(question)
+                .build();
+    }
+
+    @Builder
+    private Board(final BoardType boardType, final String title, final String content, final Member member, final Question question) {
+        this.boardType = boardType;
+        this.title = title;
+        this.content = content;
+        this.member = member;
+        this.question = question;
+    }
+}

--- a/src/main/java/goormcoder/webide/domain/Board.java
+++ b/src/main/java/goormcoder/webide/domain/Board.java
@@ -2,8 +2,11 @@ package goormcoder.webide.domain;
 
 import goormcoder.webide.domain.enums.BoardType;
 import goormcoder.webide.dto.request.BoardCreateDto;
+import goormcoder.webide.dto.request.BoardUpdateDto;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -52,5 +55,12 @@ public class Board extends BaseTimeEntity{
         this.content = content;
         this.member = member;
         this.question = question;
+    }
+
+    public void patch(BoardUpdateDto boardUpdateDto) {
+        if(!Objects.equals(this.title, boardUpdateDto.title()) || !Objects.equals(this.content, boardUpdateDto.content())) {
+            this.title = boardUpdateDto.title();
+            this.content = boardUpdateDto.content();
+        }
     }
 }

--- a/src/main/java/goormcoder/webide/domain/Board.java
+++ b/src/main/java/goormcoder/webide/domain/Board.java
@@ -1,6 +1,6 @@
 package goormcoder.webide.domain;
 
-import goormcoder.webide.domain.enums.BoardType;
+import goormcoder.webide.domain.enumeration.BoardType;
 import goormcoder.webide.dto.request.BoardCreateDto;
 import goormcoder.webide.dto.request.BoardUpdateDto;
 import jakarta.persistence.*;

--- a/src/main/java/goormcoder/webide/domain/Member.java
+++ b/src/main/java/goormcoder/webide/domain/Member.java
@@ -18,4 +18,6 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
+    @Column(name = "member_login_id", nullable = false)
+    private String loginId;
 }

--- a/src/main/java/goormcoder/webide/domain/Question.java
+++ b/src/main/java/goormcoder/webide/domain/Question.java
@@ -2,20 +2,17 @@ package goormcoder.webide.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "t_member")
+@Table(name = "t_quest")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode
-public class Member {
+public class Question {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
+    @Column(name = "quest_id")
     private Long id;
-
 }

--- a/src/main/java/goormcoder/webide/domain/Question.java
+++ b/src/main/java/goormcoder/webide/domain/Question.java
@@ -18,4 +18,8 @@ public class Question {
 
     @Column(name = "quest_num", nullable = false)
     private int questionNum;
+
+    @Column(name = "quest_content", nullable = false)
+    @Lob
+    private String content;
 }

--- a/src/main/java/goormcoder/webide/domain/Question.java
+++ b/src/main/java/goormcoder/webide/domain/Question.java
@@ -15,4 +15,7 @@ public class Question {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "quest_id")
     private Long id;
+
+    @Column(name = "quest_num", nullable = false)
+    private int questionNum;
 }

--- a/src/main/java/goormcoder/webide/domain/enumeration/BoardType.java
+++ b/src/main/java/goormcoder/webide/domain/enumeration/BoardType.java
@@ -1,4 +1,4 @@
-package goormcoder.webide.domain.enums;
+package goormcoder.webide.domain.enumeration;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/goormcoder/webide/domain/enums/BoardType.java
+++ b/src/main/java/goormcoder/webide/domain/enums/BoardType.java
@@ -1,0 +1,13 @@
+package goormcoder.webide.domain.enums;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum BoardType {
+
+    FREE_BOARD,
+    QUESTION_BOARD
+}

--- a/src/main/java/goormcoder/webide/dto/request/BoardCreateDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/BoardCreateDto.java
@@ -1,0 +1,13 @@
+package goormcoder.webide.dto.request;
+
+import goormcoder.webide.domain.enums.BoardType;
+
+public record BoardCreateDto(
+
+        Long memberId,
+        BoardType boardType,
+        String title,
+        String content,
+        Integer questionNum
+) {
+}

--- a/src/main/java/goormcoder/webide/dto/request/BoardCreateDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/BoardCreateDto.java
@@ -1,6 +1,6 @@
 package goormcoder.webide.dto.request;
 
-import goormcoder.webide.domain.enums.BoardType;
+import goormcoder.webide.domain.enumeration.BoardType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 

--- a/src/main/java/goormcoder/webide/dto/request/BoardCreateDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/BoardCreateDto.java
@@ -1,12 +1,17 @@
 package goormcoder.webide.dto.request;
 
 import goormcoder.webide.domain.enums.BoardType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record BoardCreateDto(
 
         Long memberId,
         BoardType boardType,
+        @NotBlank(message = "게시글 제목은 필수로 입력해야 합니다.")
+        @Size(max = 300, message = "게시글 제목이 최대 글자 수(300자)를 초과했습니다.")
         String title,
+        @NotBlank(message = "게시글 내용은 필수로 입력해야 합니다.")
         String content,
         Integer questionNum
 ) {

--- a/src/main/java/goormcoder/webide/dto/request/BoardUpdateDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/BoardUpdateDto.java
@@ -1,0 +1,14 @@
+package goormcoder.webide.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record BoardUpdateDto(
+
+        @NotBlank(message = "게시글 제목은 필수로 입력해야 합니다.")
+        @Size(max = 300, message = "게시글 제목이 최대 글자 수(300자)를 초과했습니다.")
+        String title,
+        @NotBlank(message = "게시글 내용은 필수로 입력해야 합니다.")
+        String content
+) {
+}

--- a/src/main/java/goormcoder/webide/dto/response/BoardFindAllDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/BoardFindAllDto.java
@@ -1,8 +1,6 @@
 package goormcoder.webide.dto.response;
 
 import goormcoder.webide.domain.Board;
-import goormcoder.webide.domain.enums.BoardType;
-import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/goormcoder/webide/dto/response/BoardFindAllDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/BoardFindAllDto.java
@@ -1,0 +1,29 @@
+package goormcoder.webide.dto.response;
+
+import goormcoder.webide.domain.Board;
+import goormcoder.webide.domain.enums.BoardType;
+import org.springframework.cglib.core.Local;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record BoardFindAllDto(
+
+        Long boarId,
+        String title,
+        LocalDateTime createdAt,
+        MemberFindDto member,
+        QuestionFindDto question
+) {
+    public static List<BoardFindAllDto> listOf(List<Board> boards) {
+        return boards
+                .stream()
+                .map(board -> new BoardFindAllDto(
+                        board.getId(),
+                        board.getTitle(),
+                        board.getCreatedAt(),
+                        MemberFindDto.from(board.getMember()),
+                        QuestionFindDto.of(board.getQuestion())
+                )).toList();
+    }
+}

--- a/src/main/java/goormcoder/webide/dto/response/BoardFindDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/BoardFindDto.java
@@ -1,0 +1,27 @@
+package goormcoder.webide.dto.response;
+
+import goormcoder.webide.domain.Board;
+import goormcoder.webide.domain.enums.BoardType;
+
+import java.time.LocalDateTime;
+
+public record BoardFindDto(
+
+        BoardType boardType,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        MemberFindDto member,
+        QuestionFindDto question
+) {
+    public static BoardFindDto from(Board board) {
+        return new BoardFindDto(
+                board.getBoardType(),
+                board.getTitle(),
+                board.getContent(),
+                board.getCreatedAt(),
+                MemberFindDto.from(board.getMember()),
+                QuestionFindDto.of(board.getQuestion())
+        );
+    }
+}

--- a/src/main/java/goormcoder/webide/dto/response/BoardFindDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/BoardFindDto.java
@@ -1,7 +1,7 @@
 package goormcoder.webide.dto.response;
 
 import goormcoder.webide.domain.Board;
-import goormcoder.webide.domain.enums.BoardType;
+import goormcoder.webide.domain.enumeration.BoardType;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/goormcoder/webide/dto/response/MemberFindDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/MemberFindDto.java
@@ -1,0 +1,15 @@
+package goormcoder.webide.dto.response;
+
+import goormcoder.webide.domain.Member;
+
+public record MemberFindDto(
+        Long id,
+        String longinId
+) {
+    public static MemberFindDto from(Member member) {
+        return new MemberFindDto(
+                member.getId(),
+                member.getLoginId()
+        );
+    }
+}

--- a/src/main/java/goormcoder/webide/dto/response/QuestionFindDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/QuestionFindDto.java
@@ -1,0 +1,20 @@
+package goormcoder.webide.dto.response;
+
+import goormcoder.webide.domain.Question;
+
+public record QuestionFindDto(
+        Long id,
+        int questionNum,
+        String questionTitle
+) {
+    public static QuestionFindDto of(Question question) {
+        if (question == null) {
+            return null;
+        }
+        return new QuestionFindDto(
+                question.getId(),
+                question.getQuestionNum(),
+                question.getContent()
+        );
+    }
+}

--- a/src/main/java/goormcoder/webide/exception/BusinessException.java
+++ b/src/main/java/goormcoder/webide/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package goormcoder.webide.exception;
+
+import goormcoder.webide.common.dto.ErrorMessage;
+
+public class BusinessException extends RuntimeException {
+    private ErrorMessage errorMessage;
+    public BusinessException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/goormcoder/webide/exception/GlobalExceptionHandler.java
+++ b/src/main/java/goormcoder/webide/exception/GlobalExceptionHandler.java
@@ -3,16 +3,21 @@ package goormcoder.webide.exception;
 import goormcoder.webide.common.dto.ErrorMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-//    @ExceptionHandler(MethodArgumentNotValidException.class)
-//    public ResponseEntity<ApiResponse<String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-//        return ApiUtils.validError(HttpStatus.BAD_REQUEST, Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage());
-//    }
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage());
+    }
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<String> handleNotFoundException(NotFoundException e){

--- a/src/main/java/goormcoder/webide/exception/GlobalExceptionHandler.java
+++ b/src/main/java/goormcoder/webide/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package goormcoder.webide.exception;
+
+import goormcoder.webide.common.dto.ErrorMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+//    @ExceptionHandler(MethodArgumentNotValidException.class)
+//    public ResponseEntity<ApiResponse<String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+//        return ApiUtils.validError(HttpStatus.BAD_REQUEST, Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage());
+//    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<String> handleNotFoundException(NotFoundException e){
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(e.getMessage());
+    }
+}

--- a/src/main/java/goormcoder/webide/exception/NotFoundException.java
+++ b/src/main/java/goormcoder/webide/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package goormcoder.webide.exception;
+
+import goormcoder.webide.common.dto.ErrorMessage;
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends BusinessException {
+
+    public NotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/goormcoder/webide/repository/BoardRepository.java
+++ b/src/main/java/goormcoder/webide/repository/BoardRepository.java
@@ -1,9 +1,16 @@
 package goormcoder.webide.repository;
 
+import goormcoder.webide.common.dto.ErrorMessage;
 import goormcoder.webide.domain.Board;
+import goormcoder.webide.domain.Member;
+import goormcoder.webide.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    default Board findByIdOrThrow(final Long boardId) {
+        return findById(boardId).orElseThrow(() -> new NotFoundException(ErrorMessage.BOARD_NOT_FOUND));
+    }
 }

--- a/src/main/java/goormcoder/webide/repository/BoardRepository.java
+++ b/src/main/java/goormcoder/webide/repository/BoardRepository.java
@@ -7,10 +7,17 @@ import goormcoder.webide.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     default Board findByIdOrThrow(final Long boardId) {
-        return findById(boardId).orElseThrow(() -> new NotFoundException(ErrorMessage.BOARD_NOT_FOUND));
+        return findByIdAndDeletedAtIsNull(boardId).orElseThrow(() -> new NotFoundException(ErrorMessage.BOARD_NOT_FOUND));
     }
+
+    Optional<Board> findByIdAndDeletedAtIsNull(Long boardId);
+
+    List<Board> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/goormcoder/webide/repository/BoardRepository.java
+++ b/src/main/java/goormcoder/webide/repository/BoardRepository.java
@@ -1,0 +1,9 @@
+package goormcoder.webide.repository;
+
+import goormcoder.webide.domain.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/goormcoder/webide/repository/MemberRepository.java
+++ b/src/main/java/goormcoder/webide/repository/MemberRepository.java
@@ -1,10 +1,15 @@
 package goormcoder.webide.repository;
 
+import goormcoder.webide.common.dto.ErrorMessage;
 import goormcoder.webide.domain.Member;
+import goormcoder.webide.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, String> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    default Member findByIdOrThrow(final Long memberId) {
+        return findById(memberId).orElseThrow(() -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/goormcoder/webide/repository/QuestionRepository.java
+++ b/src/main/java/goormcoder/webide/repository/QuestionRepository.java
@@ -1,0 +1,12 @@
+package goormcoder.webide.repository;
+
+import goormcoder.webide.domain.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+
+    Optional<Question> findByQuestionNum(Integer integer);
+}

--- a/src/main/java/goormcoder/webide/service/BoardService.java
+++ b/src/main/java/goormcoder/webide/service/BoardService.java
@@ -5,6 +5,7 @@ import goormcoder.webide.domain.Board;
 import goormcoder.webide.domain.Member;
 import goormcoder.webide.domain.Question;
 import goormcoder.webide.dto.request.BoardCreateDto;
+import goormcoder.webide.dto.request.BoardUpdateDto;
 import goormcoder.webide.dto.response.BoardFindAllDto;
 import goormcoder.webide.dto.response.BoardFindDto;
 import goormcoder.webide.exception.NotFoundException;
@@ -43,12 +44,20 @@ public class BoardService {
     //게시글 조회
     @Transactional(readOnly = true)
     public List<BoardFindAllDto> getAllBoards() {
-        return BoardFindAllDto.listOf(boardRepository.findAll());
+        return BoardFindAllDto.listOf(boardRepository.findAllByDeletedAtIsNull());
     }
 
     //게시글 열람
     @Transactional(readOnly = true)
     public BoardFindDto getBoard(Long boardId) {
         return BoardFindDto.from(boardRepository.findByIdOrThrow(boardId));
+    }
+
+    //게시글 수정
+    @Transactional
+    public void updateBoard(Long boardId, BoardUpdateDto boardUpdateDto) {
+        Board board = boardRepository.findByIdOrThrow(boardId);
+        board.patch(boardUpdateDto);
+        boardRepository.save(board);
     }
 }

--- a/src/main/java/goormcoder/webide/service/BoardService.java
+++ b/src/main/java/goormcoder/webide/service/BoardService.java
@@ -1,0 +1,38 @@
+package goormcoder.webide.service;
+
+import goormcoder.webide.common.dto.ErrorMessage;
+import goormcoder.webide.domain.Board;
+import goormcoder.webide.domain.Member;
+import goormcoder.webide.domain.Question;
+import goormcoder.webide.dto.request.BoardCreateDto;
+import goormcoder.webide.exception.NotFoundException;
+import goormcoder.webide.repository.BoardRepository;
+import goormcoder.webide.repository.MemberRepository;
+import goormcoder.webide.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final QuestionRepository questionRepository;
+
+
+    // 게시글 생성
+    @Transactional
+    public void createBoard(BoardCreateDto boardCreateDto) {
+        Member member = memberRepository.findByIdOrThrow(boardCreateDto.memberId());
+
+        Question question = null;
+        if(boardCreateDto.questionNum() != null) {
+            question = questionRepository.findByQuestionNum(boardCreateDto.questionNum())
+                    .orElseThrow(() -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND));
+        }
+
+        boardRepository.save(Board.of(boardCreateDto, member, question));
+    }
+}

--- a/src/main/java/goormcoder/webide/service/BoardService.java
+++ b/src/main/java/goormcoder/webide/service/BoardService.java
@@ -6,6 +6,7 @@ import goormcoder.webide.domain.Member;
 import goormcoder.webide.domain.Question;
 import goormcoder.webide.dto.request.BoardCreateDto;
 import goormcoder.webide.dto.response.BoardFindAllDto;
+import goormcoder.webide.dto.response.BoardFindDto;
 import goormcoder.webide.exception.NotFoundException;
 import goormcoder.webide.repository.BoardRepository;
 import goormcoder.webide.repository.MemberRepository;
@@ -40,9 +41,14 @@ public class BoardService {
     }
 
     //게시글 조회
+    @Transactional(readOnly = true)
     public List<BoardFindAllDto> getAllBoards() {
         return BoardFindAllDto.listOf(boardRepository.findAll());
     }
 
-
+    //게시글 열람
+    @Transactional(readOnly = true)
+    public BoardFindDto getBoard(Long boardId) {
+        return BoardFindDto.from(boardRepository.findByIdOrThrow(boardId));
+    }
 }

--- a/src/main/java/goormcoder/webide/service/BoardService.java
+++ b/src/main/java/goormcoder/webide/service/BoardService.java
@@ -21,7 +21,6 @@ public class BoardService {
     private final BoardRepository boardRepository;
     private final QuestionRepository questionRepository;
 
-
     // 게시글 생성
     @Transactional
     public void createBoard(BoardCreateDto boardCreateDto) {
@@ -30,7 +29,7 @@ public class BoardService {
         Question question = null;
         if(boardCreateDto.questionNum() != null) {
             question = questionRepository.findByQuestionNum(boardCreateDto.questionNum())
-                    .orElseThrow(() -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND));
+                    .orElseThrow(() -> new NotFoundException(ErrorMessage.QUESTION_NOT_FOUND));
         }
 
         boardRepository.save(Board.of(boardCreateDto, member, question));

--- a/src/main/java/goormcoder/webide/service/BoardService.java
+++ b/src/main/java/goormcoder/webide/service/BoardService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,6 +59,12 @@ public class BoardService {
     public void updateBoard(Long boardId, BoardUpdateDto boardUpdateDto) {
         Board board = boardRepository.findByIdOrThrow(boardId);
         board.patch(boardUpdateDto);
-        boardRepository.save(board);
+    }
+
+    //게시글 삭제
+    @Transactional
+    public void deleteBoard(Long boardId) {
+        Board board = boardRepository.findByIdOrThrow(boardId);
+        board.markAsDeleted(LocalDateTime.now());
     }
 }

--- a/src/main/java/goormcoder/webide/service/BoardService.java
+++ b/src/main/java/goormcoder/webide/service/BoardService.java
@@ -5,6 +5,7 @@ import goormcoder.webide.domain.Board;
 import goormcoder.webide.domain.Member;
 import goormcoder.webide.domain.Question;
 import goormcoder.webide.dto.request.BoardCreateDto;
+import goormcoder.webide.dto.response.BoardFindAllDto;
 import goormcoder.webide.exception.NotFoundException;
 import goormcoder.webide.repository.BoardRepository;
 import goormcoder.webide.repository.MemberRepository;
@@ -12,6 +13,9 @@ import goormcoder.webide.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -34,4 +38,11 @@ public class BoardService {
 
         boardRepository.save(Board.of(boardCreateDto, member, question));
     }
+
+    //게시글 조회
+    public List<BoardFindAllDto> getAllBoards() {
+        return BoardFindAllDto.listOf(boardRepository.findAll());
+    }
+
+
 }

--- a/src/main/java/goormcoder/webide/service/MemberService.java
+++ b/src/main/java/goormcoder/webide/service/MemberService.java
@@ -4,5 +4,4 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class MemberService {
-
 }


### PR DESCRIPTION
## 📚개요
게시글 등록, 조회, 열람, 수정, 삭제 구현

## 💡Key Changes
게시글 등록, 조회, 열람, 수정, 삭제 구현했습니다.
삭제는 db에서 지워지는 것이 아니라, deletedAt 컬럼이 업데이트 되는 것이기 때문에 게시글 조회 및 열람 시에 deletedAt 컬럼이 null인 것만 찾아올 수 있도록 했습니다.

``` java
    default Board findByIdOrThrow(final Long boardId) {
        return findByIdAndDeletedAtIsNull(boardId).orElseThrow(() -> new NotFoundException(ErrorMessage.BOARD_NOT_FOUND));
    }

    Optional<Board> findByIdAndDeletedAtIsNull(Long boardId);

    List<Board> findAllByDeletedAtIsNull();
```

## ✅To Reviewers
Question과 Member 도메인은 충돌을 최소화하기 위해 제가 코드 작성하면서 필요한 부분만 일단 작성해두었습니다! 
그래서 모든 컬럼을 다 작성하지 않았습니다

제가 서재님이 고쳐주시기 전에 fork를 먼저 해버린 후 작업을 해서, 충돌이 많이 있을 수 있는데, 머지하면서 해결하겠습니다!

## 🎓Reference
