### PR TITLE
feat: 댓글 로직 구현

### DIFF
--- a/src/main/java/goormcoder/webide/common/dto/ErrorMessage.java
+++ b/src/main/java/goormcoder/webide/common/dto/ErrorMessage.java
@@ -11,6 +11,7 @@ public enum ErrorMessage {
     MEMBER_NOT_FOUND("해당하는 사용자가 존재하지 않습니다."),
     QUESTION_NOT_FOUND("해당하는 문제가 존재하지 않습니다."),
     BOARD_NOT_FOUND("해당하는 게시글이 존재하지 않습니다."),
+    COMMENT_NOT_FOUND("해당하는 댓글이 존재하지 않습니다."),
     ;
 
     private final String message;

--- a/src/main/java/goormcoder/webide/controller/BoardController.java
+++ b/src/main/java/goormcoder/webide/controller/BoardController.java
@@ -20,33 +20,33 @@ public class BoardController {
     private final BoardService boardService;
 
     //게시글 등록
-    @PostMapping("/board")
+    @PostMapping("/boards")
     public ResponseEntity<?> createBoard(@Valid @RequestBody BoardCreateDto boardCreateDto) {
         boardService.createBoard(boardCreateDto);
         return ResponseEntity.status(HttpStatus.OK).body("게시글이 생성되었습니다.");
     }
 
     //게시글 조회
-    @GetMapping("/board/all")
+    @GetMapping("/boards/all")
     public ResponseEntity<List<BoardFindAllDto>> getAllBoards() {
         return ResponseEntity.status(HttpStatus.OK).body(boardService.getAllBoards());
     }
 
     //게시글 열람
-    @GetMapping("/board/{boardId}")
+    @GetMapping("/boards/{boardId}")
     public ResponseEntity<BoardFindDto> getBoard(@PathVariable Long boardId) {
         return ResponseEntity.status(HttpStatus.OK).body(boardService.getBoard(boardId));
     }
 
     //게시글 수정
-    @PatchMapping("/board/{boardId}")
+    @PatchMapping("/boards/{boardId}")
     public ResponseEntity<?> updateBoard(@PathVariable Long boardId, @Valid @RequestBody BoardUpdateDto boardUpdateDto) {
         boardService.updateBoard(boardId, boardUpdateDto);
         return ResponseEntity.status(HttpStatus.OK).body("게시글 수정이 완료되었습니다.");
     }
 
     //게시글 삭제
-    @DeleteMapping("/board/{boardId}")
+    @DeleteMapping("/boards/{boardId}")
     public ResponseEntity<?> deleteBoard(@PathVariable Long boardId) {
         boardService.deleteBoard(boardId);
         return ResponseEntity.status(HttpStatus.OK).body("게시글 삭제가 완료되었습니다.");

--- a/src/main/java/goormcoder/webide/controller/CommentController.java
+++ b/src/main/java/goormcoder/webide/controller/CommentController.java
@@ -1,6 +1,7 @@
 package goormcoder.webide.controller;
 
 import goormcoder.webide.dto.request.CommentCreateDto;
+import goormcoder.webide.dto.request.CommentUpdateDto;
 import goormcoder.webide.dto.response.CommentFindAllDto;
 import goormcoder.webide.service.CommentService;
 import lombok.RequiredArgsConstructor;
@@ -27,5 +28,12 @@ public class CommentController {
     @GetMapping("/boards/{boardId}/comments")
     public ResponseEntity<List<CommentFindAllDto>> getComments(@PathVariable Long boardId) {
         return ResponseEntity.status(HttpStatus.OK).body(commentService.getComments(boardId));
+    }
+
+    //댓글 수정
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<?> updateComment(@PathVariable Long commentId, @RequestBody CommentUpdateDto commentUpdateDto) {
+        commentService.updateComment(commentId, commentUpdateDto);
+        return ResponseEntity.status(HttpStatus.OK).body("댓글 수정이 완료되었습니다.");
     }
 }

--- a/src/main/java/goormcoder/webide/controller/CommentController.java
+++ b/src/main/java/goormcoder/webide/controller/CommentController.java
@@ -4,6 +4,7 @@ import goormcoder.webide.dto.request.CommentCreateDto;
 import goormcoder.webide.dto.request.CommentUpdateDto;
 import goormcoder.webide.dto.response.CommentFindAllDto;
 import goormcoder.webide.service.CommentService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class CommentController {
 
     //댓글 생성
     @PostMapping("/boards/{boardId}/comments")
-    public ResponseEntity<?> createComment(@PathVariable Long boardId, @RequestBody CommentCreateDto commentCreateDto) {
+    public ResponseEntity<?> createComment(@PathVariable Long boardId, @Valid @RequestBody CommentCreateDto commentCreateDto) {
         commentService.createComment(boardId, commentCreateDto);
         return ResponseEntity.status(HttpStatus.OK).body("댓글이 생성되었습니다.");
     }
@@ -32,7 +33,7 @@ public class CommentController {
 
     //댓글 수정
     @PatchMapping("/comments/{commentId}")
-    public ResponseEntity<?> updateComment(@PathVariable Long commentId, @RequestBody CommentUpdateDto commentUpdateDto) {
+    public ResponseEntity<?> updateComment(@PathVariable Long commentId, @Valid @RequestBody CommentUpdateDto commentUpdateDto) {
         commentService.updateComment(commentId, commentUpdateDto);
         return ResponseEntity.status(HttpStatus.OK).body("댓글 수정이 완료되었습니다.");
     }

--- a/src/main/java/goormcoder/webide/controller/CommentController.java
+++ b/src/main/java/goormcoder/webide/controller/CommentController.java
@@ -36,4 +36,11 @@ public class CommentController {
         commentService.updateComment(commentId, commentUpdateDto);
         return ResponseEntity.status(HttpStatus.OK).body("댓글 수정이 완료되었습니다.");
     }
+
+    //댓글 삭제
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+        return ResponseEntity.status(HttpStatus.OK).body("댓글 삭제가 완료되었습니다.");
+    }
 }

--- a/src/main/java/goormcoder/webide/controller/CommentController.java
+++ b/src/main/java/goormcoder/webide/controller/CommentController.java
@@ -1,0 +1,31 @@
+package goormcoder.webide.controller;
+
+import goormcoder.webide.dto.request.CommentCreateDto;
+import goormcoder.webide.dto.response.CommentFindAllDto;
+import goormcoder.webide.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    //댓글 생성
+    @PostMapping("/boards/{boardId}/comments")
+    public ResponseEntity<?> createComment(@PathVariable Long boardId, @RequestBody CommentCreateDto commentCreateDto) {
+        commentService.createComment(boardId, commentCreateDto);
+        return ResponseEntity.status(HttpStatus.OK).body("댓글이 생성되었습니다.");
+    }
+
+    //댓글 조회
+    @GetMapping("/boards/{boardId}/comments")
+    public ResponseEntity<List<CommentFindAllDto>> getComments(@PathVariable Long boardId) {
+        return ResponseEntity.status(HttpStatus.OK).body(commentService.getComments(boardId));
+    }
+}

--- a/src/main/java/goormcoder/webide/domain/Board.java
+++ b/src/main/java/goormcoder/webide/domain/Board.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 @Getter
 @Table(name = "t_board")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Board extends BaseTimeEntity{
 
     @Id

--- a/src/main/java/goormcoder/webide/domain/Comment.java
+++ b/src/main/java/goormcoder/webide/domain/Comment.java
@@ -48,7 +48,7 @@ public class Comment extends BaseTimeEntity {
     }
 
     public void patch(CommentUpdateDto commentUpdateDto) {
-        if (Objects.equals(this.content, commentUpdateDto.content())) {
+        if (!Objects.equals(this.content, commentUpdateDto.content())) {
             this.content = commentUpdateDto.content();
         }
     }

--- a/src/main/java/goormcoder/webide/domain/Comment.java
+++ b/src/main/java/goormcoder/webide/domain/Comment.java
@@ -1,11 +1,14 @@
 package goormcoder.webide.domain;
 
 import goormcoder.webide.dto.request.CommentCreateDto;
+import goormcoder.webide.dto.request.CommentUpdateDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -42,5 +45,11 @@ public class Comment extends BaseTimeEntity {
         this.content = content;
         this.board = board;
         this.member = member;
+    }
+
+    public void patch(CommentUpdateDto commentUpdateDto) {
+        if (Objects.equals(this.content, commentUpdateDto.content())) {
+            this.content = commentUpdateDto.content();
+        }
     }
 }

--- a/src/main/java/goormcoder/webide/domain/Comment.java
+++ b/src/main/java/goormcoder/webide/domain/Comment.java
@@ -1,0 +1,46 @@
+package goormcoder.webide.domain;
+
+import goormcoder.webide.dto.request.CommentCreateDto;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "t_comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(name = "comment_content", nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public static Comment of(final CommentCreateDto commentCreateDto, final Board board, final Member member) {
+        return Comment.builder()
+                .content(commentCreateDto.content())
+                .board(board)
+                .member(member)
+                .build();
+    }
+
+    @Builder
+    public Comment(String content, Board board, Member member) {
+        this.content = content;
+        this.board = board;
+        this.member = member;
+    }
+}

--- a/src/main/java/goormcoder/webide/dto/request/CommentCreateDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/CommentCreateDto.java
@@ -1,8 +1,13 @@
 package goormcoder.webide.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record CommentCreateDto(
 
         Long memberId,
+        @NotBlank(message = "댓글 내용은 필수로 입력해야 합니다.")
+        @Size(max = 4000, message = "댓글 내용이 최대 글자 수(4000자)를 초과했습니다.")
         String content
 ) {
 }

--- a/src/main/java/goormcoder/webide/dto/request/CommentCreateDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/CommentCreateDto.java
@@ -1,0 +1,8 @@
+package goormcoder.webide.dto.request;
+
+public record CommentCreateDto(
+
+        Long memberId,
+        String content
+) {
+}

--- a/src/main/java/goormcoder/webide/dto/request/CommentUpdateDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/CommentUpdateDto.java
@@ -1,7 +1,12 @@
 package goormcoder.webide.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record CommentUpdateDto(
 
+        @NotBlank(message = "댓글 내용은 필수로 입력해야 합니다.")
+        @Size(max = 4000, message = "댓글 내용이 최대 글자 수(4000자)를 초과했습니다.")
         String content
 ) {
 }

--- a/src/main/java/goormcoder/webide/dto/request/CommentUpdateDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/CommentUpdateDto.java
@@ -1,0 +1,7 @@
+package goormcoder.webide.dto.request;
+
+public record CommentUpdateDto(
+
+        String content
+) {
+}

--- a/src/main/java/goormcoder/webide/dto/response/BoardFindDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/BoardFindDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 public record BoardFindDto(
 
+        Long boarId,
         BoardType boardType,
         String title,
         String content,
@@ -16,6 +17,7 @@ public record BoardFindDto(
 ) {
     public static BoardFindDto from(Board board) {
         return new BoardFindDto(
+                board.getId(),
                 board.getBoardType(),
                 board.getTitle(),
                 board.getContent(),

--- a/src/main/java/goormcoder/webide/dto/response/CommentFindAllDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/CommentFindAllDto.java
@@ -1,0 +1,25 @@
+package goormcoder.webide.dto.response;
+
+import goormcoder.webide.domain.Comment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CommentFindAllDto(
+
+        Long commentId,
+        String comment,
+        LocalDateTime createdAt,
+        MemberFindDto member
+) {
+    public static List<CommentFindAllDto> listOf(List<Comment> comments) {
+        return comments
+                .stream()
+                .map(comment -> new CommentFindAllDto(
+                        comment.getId(),
+                        comment.getContent(),
+                        comment.getCreatedAt(),
+                        MemberFindDto.from(comment.getMember())
+                )).toList();
+    }
+}

--- a/src/main/java/goormcoder/webide/repository/CommentRepository.java
+++ b/src/main/java/goormcoder/webide/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package goormcoder.webide.repository;
+
+import goormcoder.webide.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("select c from Comment c where c.board.id = :boardId and c.deletedAt is null")
+    List<Comment> findAllByBoardId(Long boardId);
+}

--- a/src/main/java/goormcoder/webide/repository/CommentRepository.java
+++ b/src/main/java/goormcoder/webide/repository/CommentRepository.java
@@ -1,14 +1,24 @@
 package goormcoder.webide.repository;
 
+import goormcoder.webide.common.dto.ErrorMessage;
+import goormcoder.webide.domain.Board;
 import goormcoder.webide.domain.Comment;
+import goormcoder.webide.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    default Comment findByIdOrThrow(final Long commentId) {
+        return findByIdAndDeletedAtIsNull(commentId).orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND));
+    }
+
+    Optional<Comment> findByIdAndDeletedAtIsNull(Long commentId);
 
     @Query("select c from Comment c where c.board.id = :boardId and c.deletedAt is null")
     List<Comment> findAllByBoardId(Long boardId);

--- a/src/main/java/goormcoder/webide/service/CommentService.java
+++ b/src/main/java/goormcoder/webide/service/CommentService.java
@@ -1,0 +1,37 @@
+package goormcoder.webide.service;
+
+import goormcoder.webide.domain.Board;
+import goormcoder.webide.domain.Comment;
+import goormcoder.webide.domain.Member;
+import goormcoder.webide.dto.request.CommentCreateDto;
+import goormcoder.webide.dto.response.CommentFindAllDto;
+import goormcoder.webide.repository.BoardRepository;
+import goormcoder.webide.repository.CommentRepository;
+import goormcoder.webide.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+
+    //댓글 생성
+    public void createComment(Long boardId, CommentCreateDto commentCreateDto) {
+        Board board = boardRepository.findByIdOrThrow(boardId);
+        Member member = memberRepository.findByIdOrThrow(commentCreateDto.memberId()); //나중에 수정해야함
+        commentRepository.save(Comment.of(commentCreateDto, board, member));
+    }
+
+    //댓글 조회
+    public List<CommentFindAllDto> getComments(Long boardId) {
+        List<Comment> comments = commentRepository.findAllByBoardId(boardId);
+        return CommentFindAllDto.listOf(comments);
+    }
+
+}

--- a/src/main/java/goormcoder/webide/service/CommentService.java
+++ b/src/main/java/goormcoder/webide/service/CommentService.java
@@ -11,7 +11,9 @@ import goormcoder.webide.repository.CommentRepository;
 import goormcoder.webide.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -23,6 +25,7 @@ public class CommentService {
     private final MemberRepository memberRepository;
 
     //댓글 생성
+    @Transactional
     public void createComment(Long boardId, CommentCreateDto commentCreateDto) {
         Board board = boardRepository.findByIdOrThrow(boardId);
         Member member = memberRepository.findByIdOrThrow(commentCreateDto.memberId()); //나중에 수정해야함
@@ -30,12 +33,14 @@ public class CommentService {
     }
 
     //댓글 조회
+    @Transactional(readOnly = true)
     public List<CommentFindAllDto> getComments(Long boardId) {
         List<Comment> comments = commentRepository.findAllByBoardId(boardId);
         return CommentFindAllDto.listOf(comments);
     }
 
     //댓글 수정
+    @Transactional
     public void updateComment(Long commentId, CommentUpdateDto commentUpdateDto) {
         Comment comment = commentRepository.findByIdOrThrow(commentId);
 
@@ -44,5 +49,17 @@ public class CommentService {
 //            throw new ForbiddenException(ErrorMessage.FORBIDDEN_MEMBER_ACCESS);
 //        }
         comment.patch(commentUpdateDto);
+    }
+
+    //댓글 삭제
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
+
+        //jwt 이후 추가 예정
+//        if(!memberId.equals(comment.getMember().getId())) {
+//            throw new ForbiddenException(ErrorMessage.FORBIDDEN_MEMBER_ACCESS);
+//        }
+        comment.markAsDeleted(LocalDateTime.now());
     }
 }

--- a/src/main/java/goormcoder/webide/service/CommentService.java
+++ b/src/main/java/goormcoder/webide/service/CommentService.java
@@ -4,6 +4,7 @@ import goormcoder.webide.domain.Board;
 import goormcoder.webide.domain.Comment;
 import goormcoder.webide.domain.Member;
 import goormcoder.webide.dto.request.CommentCreateDto;
+import goormcoder.webide.dto.request.CommentUpdateDto;
 import goormcoder.webide.dto.response.CommentFindAllDto;
 import goormcoder.webide.repository.BoardRepository;
 import goormcoder.webide.repository.CommentRepository;
@@ -34,4 +35,14 @@ public class CommentService {
         return CommentFindAllDto.listOf(comments);
     }
 
+    //댓글 수정
+    public void updateComment(Long commentId, CommentUpdateDto commentUpdateDto) {
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
+
+        //jwt 이후 추가 예정
+//        if(!memberId.equals(comment.getMember().getId())) {
+//            throw new ForbiddenException(ErrorMessage.FORBIDDEN_MEMBER_ACCESS);
+//        }
+        comment.patch(commentUpdateDto);
+    }
 }


### PR DESCRIPTION
## 📚개요
댓글 등록, 조회, 수정, 삭제 구현

## 💡Key Changes
1. board 엔드 포인트 수정하였습니다. board -> boards
2. 댓글 등록, 조회, 수정, 삭제 구현하였습니다. 

## ✅To Reviewers
아직 로그인 기능이 없어서 requestBody로 memberId 받아오는 걸로 구현하였는데, 후에 jwt 추가되면 토큰 통해 받아오는 것을 수정하겠습니다!

## 🎓Reference