### PR TITLE
feat: 로그인 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/goormcoder/webide/config/SecurityConfig.java
+++ b/src/main/java/goormcoder/webide/config/SecurityConfig.java
@@ -1,0 +1,71 @@
+package goormcoder.webide.config;
+
+import goormcoder.webide.jwt.JwtProvider;
+import goormcoder.webide.util.filter.JwtAuthenticationFilter;
+import goormcoder.webide.util.filter.JwtAuthorizationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private static final String TEST_WHITE_LIST = "/h2-console/**";
+
+    private static final String ADMIN = "/admin/**";
+    private static final String[] WHITE_LIST = {"/", "/members/join", "/members/login"};
+
+    private final JwtProvider jwtProvider;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        http.authorizeHttpRequests((auth) -> auth
+                .requestMatchers(TEST_WHITE_LIST).permitAll()
+                .requestMatchers(WHITE_LIST).permitAll()
+                .requestMatchers(ADMIN).hasRole("ADMIN")
+                .anyRequest().authenticated());
+
+        // for using H2
+        http.headers(headers -> headers.frameOptions(
+                HeadersConfigurer.FrameOptionsConfig::sameOrigin
+        ));
+
+        http.addFilterAt(
+                new JwtAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtProvider),
+                UsernamePasswordAuthenticationFilter.class);
+
+        http.sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/goormcoder/webide/config/SecurityConfig.java
+++ b/src/main/java/goormcoder/webide/config/SecurityConfig.java
@@ -57,6 +57,8 @@ public class SecurityConfig {
         http.headers(headers -> headers.frameOptions(
                 HeadersConfigurer.FrameOptionsConfig::sameOrigin
         ));
+        
+        http.addFilterBefore(new JwtAuthorizationFilter(jwtProvider), JwtAuthenticationFilter.class);
 
         http.addFilterAt(
                 new JwtAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtProvider),

--- a/src/main/java/goormcoder/webide/domain/Member.java
+++ b/src/main/java/goormcoder/webide/domain/Member.java
@@ -1,13 +1,14 @@
 package goormcoder.webide.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import goormcoder.webide.domain.enumeration.Gender;
+import goormcoder.webide.domain.enumeration.MemberRole;
+import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Entity
 @NoArgsConstructor
@@ -19,5 +20,62 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
+
+    @Column(name = "member_login_id", nullable = false, unique = true)
+    private String loginId;
+
+    @Column(name = "member_pw", nullable = false)
+    private String password;
+
+    @Column(name = "member_nick", nullable = false)
+    private String nick;
+
+    @Column(name = "member_name", nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_role", nullable = false)
+    private MemberRole role;
+
+    @Column(name = "member_birth", nullable = false)
+    private LocalDate birth;
+
+    @Column(name = "member_email", unique = true)
+    private String email;
+
+    @Column(name = "member_info")
+    private String info;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_gender", nullable = false)
+    private Gender gender;
+
+    @Builder
+    private Member(String loginId, String password, String nick, String name, MemberRole role, LocalDate birth, String email, String info, Gender gender) {
+        this.loginId = loginId;
+        this.password = password;
+        this.nick = nick;
+        this.name = name;
+        this.role = role;
+        this.birth = birth;
+        this.email = email;
+        this.info = info;
+        this.gender = gender;
+    }
+
+    public static Member of(String loginId, String password, String nick, String name, MemberRole role,
+                            LocalDate birth, String email, String info, Gender gender) {
+        return Member.builder()
+                .loginId(loginId)
+                .password(password)
+                .nick(nick)
+                .name(name)
+                .role(role)
+                .birth(birth)
+                .email(email)
+                .info(info)
+                .gender(gender)
+                .build();
+    }
 
 }

--- a/src/main/java/goormcoder/webide/domain/enumeration/MemberRole.java
+++ b/src/main/java/goormcoder/webide/domain/enumeration/MemberRole.java
@@ -1,5 +1,6 @@
 package goormcoder.webide.domain.enumeration;
 
 public enum MemberRole {
-    USER, ADMIN
+    ROLE_USER, ROLE_ADMIN
+
 }

--- a/src/main/java/goormcoder/webide/dto/request/MemberLoginDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/MemberLoginDto.java
@@ -1,0 +1,10 @@
+package goormcoder.webide.dto.request;
+
+public record MemberLoginDto(
+
+        String loginId,
+        String password
+
+) {
+
+}

--- a/src/main/java/goormcoder/webide/dto/response/JwtToken.java
+++ b/src/main/java/goormcoder/webide/dto/response/JwtToken.java
@@ -1,0 +1,15 @@
+package goormcoder.webide.dto.response;
+
+public record JwtToken(
+
+        String loginId,
+        String accessToken,
+        String refreshToken
+
+) {
+
+    public static JwtToken of(String loginId, String accessToken, String refreshToken) {
+        return new JwtToken(loginId, accessToken, refreshToken);
+    }
+
+}

--- a/src/main/java/goormcoder/webide/jwt/JwtProvider.java
+++ b/src/main/java/goormcoder/webide/jwt/JwtProvider.java
@@ -1,0 +1,78 @@
+package goormcoder.webide.jwt;
+
+import goormcoder.webide.domain.enumeration.MemberRole;
+import goormcoder.webide.security.MemberDetails;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 10 * 60 * 1000L; // 10분
+    private static final long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 7; // 7일
+
+    private final SecretKey secretKey;
+
+    public JwtProvider(@Value("${jwt.secret}") String secretKey) {
+        String encodeKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+        this.secretKey = Keys.hmacShaKeyFor(encodeKey.getBytes());
+    }
+
+    public String getUsername(String token) {
+        return getClaims(token).get("loginId", String.class);
+    }
+
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return getClaims(token).getExpiration().before(new Date());
+    }
+
+    public String issueAccessToken(final Authentication authentication) {
+        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    public String issueRefreshToken(final Authentication authentication) {
+        return generateToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME);
+    }
+
+    private String generateToken(Authentication authentication, long expirationTime) {
+        final Date now = new Date();
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expirationTime));
+
+        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+        claims.put("loginId", memberDetails.getUsername());
+        claims.put("role", memberDetails.getAuthorities().stream().toList().get(0).getAuthority());
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+}

--- a/src/main/java/goormcoder/webide/repository/MemberRepository.java
+++ b/src/main/java/goormcoder/webide/repository/MemberRepository.java
@@ -4,7 +4,11 @@ import goormcoder.webide.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface MemberRepository extends JpaRepository<Member, String> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByLoginId(String loginId);
 
 }

--- a/src/main/java/goormcoder/webide/security/MemberDetails.java
+++ b/src/main/java/goormcoder/webide/security/MemberDetails.java
@@ -1,0 +1,54 @@
+package goormcoder.webide.security;
+
+import goormcoder.webide.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class MemberDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(member.getRole().name()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getLoginId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/goormcoder/webide/service/MemberDetailService.java
+++ b/src/main/java/goormcoder/webide/service/MemberDetailService.java
@@ -1,0 +1,27 @@
+package goormcoder.webide.service;
+
+import goormcoder.webide.domain.Member;
+import goormcoder.webide.security.MemberDetails;
+import goormcoder.webide.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberDetailService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with loginId: " + loginId));
+        return new MemberDetails(member);
+    }
+
+}

--- a/src/main/java/goormcoder/webide/util/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/goormcoder/webide/util/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package goormcoder.webide.util.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import goormcoder.webide.dto.request.MemberLoginDto;
+import goormcoder.webide.dto.response.JwtToken;
+import goormcoder.webide.jwt.JwtProvider;
+import goormcoder.webide.security.MemberDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final JwtProvider jwtProvider;
+    private final AuthenticationManager authenticationManager;
+
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+        this.authenticationManager = authenticationManager;
+        setFilterProcessesUrl("/members/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            MemberLoginDto loginRequest = new ObjectMapper().readValue(request.getInputStream(), MemberLoginDto.class);
+            UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                    loginRequest.loginId(), loginRequest.password()
+            );
+            return authenticationManager.authenticate(token);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse authentication request body", e);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        log.info("[JwtAuthenticationFilter] login success");
+
+        String loginId = ((MemberDetails) authResult.getPrincipal()).getUsername();
+
+        String accessToken = jwtProvider.issueAccessToken(authResult);
+        String refreshToken = jwtProvider.issueRefreshToken(authResult);
+
+        JwtToken jwtToken = JwtToken.of(loginId, accessToken, refreshToken);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().write(new ObjectMapper().writeValueAsString(jwtToken));
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        log.info("[JwtAuthenticationFilter] login fail");
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"" + failed.getMessage() + "\"}");
+    }
+
+}

--- a/src/main/java/goormcoder/webide/util/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/goormcoder/webide/util/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,54 @@
+package goormcoder.webide.util.filter;
+
+import goormcoder.webide.domain.Member;
+import goormcoder.webide.domain.enumeration.MemberRole;
+import goormcoder.webide.jwt.JwtProvider;
+import goormcoder.webide.security.MemberDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorization = request.getHeader("Authorization");
+
+        // Authorization Header 검증
+        if(authorization == null || !authorization.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorization.split(" ")[1];
+
+        String loginId = jwtProvider.getUsername(token);
+        String role = jwtProvider.getRole(token);
+
+        Member data = Member.builder()
+                .loginId(loginId)
+                .password("password")
+                .role(MemberRole.valueOf(role.toUpperCase()))
+                .build();
+
+        MemberDetails memberDetails = new MemberDetails(data);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+        filterChain.doFilter(request, response);
+    }
+
+}


### PR DESCRIPTION
**인증(Authentication)**
- 로그인 성공 시 JWT 토큰 발급
- Expiration Time
   - Access Token : 10분
   - Refresh Token : 7일

<br>

**인가(Authorization)**
- `/, /members/join, /members/login` : 모든 사용자 접근 가능
- `/admin/**` : 관리자만 접근 가능
- 이외 경로 : 로그인한 사용자만 접근 가능

<br>

> 아직 예외 처리 및 응답은 반영하지 않았습니다.
 채원님 내용 Sync 받아서 예외 처리 로직은 따로 PR 예정입니다.