### PR TITLE
feat & fix: 채팅방 삭제 로직 구현 및 채팅방 생성 응답 변경

### DIFF
--- a/src/main/java/goormcoder/webide/constants/ErrorMessages.java
+++ b/src/main/java/goormcoder/webide/constants/ErrorMessages.java
@@ -34,6 +34,7 @@ public enum ErrorMessages {
     FORBIDDEN_BOARD_ACCESS("해당 게시글에 대한 접근 권한이 없습니다."),
     FORBIDDEN_COMMENT_ACCESS("해당 게시글에 대한 접근 권한이 없습니다."),
     FORBIDDEN_FRIEND_REQUEST_ACCESS("해당 친구 요청에 대한 접근 권한이 없습니다."),
+    FORBIDDEN_CHATROOM_ACCESS("해당 채팅방에 대한 접근 권한이 없습니다."),
 
     //400 BAD_REQUEST
     BAD_REQUEST_INVITED_ID("본인과의 채팅방은 생성할 수 없습니다."),

--- a/src/main/java/goormcoder/webide/controller/ChatController.java
+++ b/src/main/java/goormcoder/webide/controller/ChatController.java
@@ -7,6 +7,7 @@ import goormcoder.webide.dto.response.ChatMessageFindDto;
 import goormcoder.webide.dto.response.ChatRoomFindAllDto;
 import goormcoder.webide.jwt.PrincipalHandler;
 import goormcoder.webide.service.ChatMessageService;
+import goormcoder.webide.service.ChatRoomMemberService;
 import goormcoder.webide.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -54,6 +55,13 @@ public class ChatController {
     public ResponseEntity<List<ChatRoomFindAllDto>> getMyChatRooms() {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(chatRoomService.getMyChatRooms(principalHandler.getMemberLoginId()));
+    }
+
+    @DeleteMapping("/chats/rooms/{chatRoomId}")
+    @Operation(summary = "채팅방 삭제", description = "사용자의 특정 채팅방을 삭제합니다.")
+    public ResponseEntity<String> deleteMyChatRoom(@PathVariable Long chatRoomId) {
+        chatRoomService.deleteMyChatRoom(chatRoomId, principalHandler.getMemberLoginId());
+        return ResponseEntity.status(HttpStatus.OK).body("채팅방이 삭제되었습니다.");
     }
 
     @GetMapping("/chats/rooms/{chatRoomId}")

--- a/src/main/java/goormcoder/webide/controller/ChatController.java
+++ b/src/main/java/goormcoder/webide/controller/ChatController.java
@@ -5,6 +5,7 @@ import goormcoder.webide.dto.request.ChatMessageSendDto;
 import goormcoder.webide.dto.request.ChatRoomCreateDto;
 import goormcoder.webide.dto.response.ChatMessageFindDto;
 import goormcoder.webide.dto.response.ChatRoomFindAllDto;
+import goormcoder.webide.dto.response.ChatRoomFindDto;
 import goormcoder.webide.jwt.PrincipalHandler;
 import goormcoder.webide.service.ChatMessageService;
 import goormcoder.webide.service.ChatRoomMemberService;
@@ -45,9 +46,10 @@ public class ChatController {
 
     @PostMapping("/chats/rooms")
     @Operation(summary = "채팅방 생성", description = "채팅방을 생성합니다.")
-    public ResponseEntity<String> createChatRoom(@Valid @RequestBody ChatRoomCreateDto chatRoomCreateDto) {
-        chatRoomService.createChatRoom(principalHandler.getMemberLoginId(), chatRoomCreateDto);
-        return ResponseEntity.status(HttpStatus.OK).body("채팅방이 생성되었습니다.");
+    public ResponseEntity<ChatRoomFindDto> createChatRoom(@Valid @RequestBody ChatRoomCreateDto chatRoomCreateDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                chatRoomService.createChatRoom(principalHandler.getMemberLoginId(), chatRoomCreateDto)
+        );
     }
 
     @GetMapping("/chats/rooms")

--- a/src/main/java/goormcoder/webide/controller/ChatController.java
+++ b/src/main/java/goormcoder/webide/controller/ChatController.java
@@ -60,7 +60,7 @@ public class ChatController {
     @Operation(summary = "메시지 조회", description = "특정 채팅방의 메시지를 조회합니다. 메시지는 생성일 기준 내림차순 정렬되어있습니다.")
     public ResponseEntity<List<ChatMessageFindDto>> getChatRoomMessages(@PathVariable Long chatRoomId) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(chatMessageService.getChatRoomMessages(chatRoomId));
+                .body(chatMessageService.getChatRoomMessages(chatRoomId, principalHandler.getMemberLoginId()));
     }
 
 }

--- a/src/main/java/goormcoder/webide/domain/ChatRoom.java
+++ b/src/main/java/goormcoder/webide/domain/ChatRoom.java
@@ -31,7 +31,7 @@ public class ChatRoom extends BaseTimeEntity {
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.PERSIST)
     private final Set<ChatRoomMember> chatRoomMembers = new HashSet<>();
 
-    @OneToMany(mappedBy = "chatRoom", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.PERSIST)
     private final List<ChatMessage> chatMessages = new ArrayList<>();
 
     @Builder
@@ -55,4 +55,9 @@ public class ChatRoom extends BaseTimeEntity {
         chatMessages.add(chatMessage);
     }
 
+    @Override
+    public void markAsDeleted() {
+        super.markAsDeleted();
+        chatMessages.forEach(ChatMessage::markAsDeleted);
+    }
 }

--- a/src/main/java/goormcoder/webide/domain/ChatRoom.java
+++ b/src/main/java/goormcoder/webide/domain/ChatRoom.java
@@ -55,6 +55,10 @@ public class ChatRoom extends BaseTimeEntity {
         chatMessages.add(chatMessage);
     }
 
+    public void deleteUniqueKey() {
+        this.uniqueKey = null;
+    }
+
     @Override
     public void markAsDeleted() {
         super.markAsDeleted();

--- a/src/main/java/goormcoder/webide/domain/ChatRoomMember.java
+++ b/src/main/java/goormcoder/webide/domain/ChatRoomMember.java
@@ -28,6 +28,10 @@ public class ChatRoomMember {
     @Column(name = "read_at", nullable = false)
     private LocalDateTime readAt;
 
+    @Setter
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder
     private ChatRoomMember(Member member, ChatRoom chatRoom, LocalDateTime readAt) {
         this.member = member;
@@ -41,6 +45,10 @@ public class ChatRoomMember {
                 .chatRoom(chatRoom)
                 .readAt(LocalDateTime.now())
                 .build();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
     }
 
 }

--- a/src/main/java/goormcoder/webide/domain/ChatRoomMember.java
+++ b/src/main/java/goormcoder/webide/domain/ChatRoomMember.java
@@ -28,7 +28,6 @@ public class ChatRoomMember {
     @Column(name = "read_at", nullable = false)
     private LocalDateTime readAt;
 
-    @Setter
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
@@ -49,6 +48,10 @@ public class ChatRoomMember {
 
     public boolean isDeleted() {
         return deletedAt != null;
+    }
+
+    public void markAsDeleted() {
+        this.deletedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/goormcoder/webide/domain/ChatRoomMember.java
+++ b/src/main/java/goormcoder/webide/domain/ChatRoomMember.java
@@ -24,7 +24,6 @@ public class ChatRoomMember {
     @JoinColumn(name = "chat_room_id", nullable = false)
     private ChatRoom chatRoom;
 
-    @Setter
     @Column(name = "read_at", nullable = false)
     private LocalDateTime readAt;
 
@@ -52,6 +51,10 @@ public class ChatRoomMember {
 
     public void markAsDeleted() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void markAsRead(LocalDateTime readAt) {
+        this.readAt = readAt;
     }
 
 }

--- a/src/main/java/goormcoder/webide/dto/response/ChatRoomFindDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/ChatRoomFindDto.java
@@ -1,0 +1,15 @@
+package goormcoder.webide.dto.response;
+
+import goormcoder.webide.domain.ChatRoom;
+
+public record ChatRoomFindDto(
+
+        Long chatRoomId
+
+) {
+
+    public static ChatRoomFindDto of(ChatRoom chatRoom) {
+        return new ChatRoomFindDto(chatRoom.getId());
+    }
+
+}

--- a/src/main/java/goormcoder/webide/exception/WebSocketExceptionHandler.java
+++ b/src/main/java/goormcoder/webide/exception/WebSocketExceptionHandler.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class WebSocketExceptionHandler {
 
     @MessageExceptionHandler
-    @SendTo("/pub/queue/errors")
+    @SendTo("/sub/queue/errors")
     public String handleException(Exception exception) {
         return exception.getMessage();
     }

--- a/src/main/java/goormcoder/webide/repository/ChatRoomRepository.java
+++ b/src/main/java/goormcoder/webide/repository/ChatRoomRepository.java
@@ -14,7 +14,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     boolean existsByUniqueKey(String uniqueKey);
 
-    @Query("SELECT cr FROM ChatRoom cr JOIN cr.chatRoomMembers crm JOIN crm.member m WHERE m.loginId = :loginId")
+    @Query("SELECT cr FROM ChatRoom cr JOIN cr.chatRoomMembers crm JOIN crm.member m WHERE m.loginId = :loginId AND crm.deletedAt IS NULL")
     List<ChatRoom> findChatRoomsByMemberLoginId(@Param("loginId") String loginId);
 
     @Query("SELECT m.name FROM Member m JOIN ChatRoomMember crm ON m.id = crm.member.id WHERE crm.chatRoom.id = :chatRoomId AND m.loginId <> :currentUserLoginId")

--- a/src/main/java/goormcoder/webide/service/ChatMessageService.java
+++ b/src/main/java/goormcoder/webide/service/ChatMessageService.java
@@ -27,6 +27,7 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatRoomMemberService chatRoomMemberService;
 
     @Transactional
     public ChatMessage saveMessage(ChatMessageSendDto chatMessageSendDto) {
@@ -43,7 +44,10 @@ public class ChatMessageService {
     }
 
     @Transactional
-    public List<ChatMessageFindDto> getChatRoomMessages(Long chatRoomId) {
+    public List<ChatMessageFindDto> getChatRoomMessages(Long chatRoomId, String loginId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.CHATROOM_NOT_FOUND.getMessage()));
+        chatRoomMemberService.checkChatRoomMember(chatRoom, loginId);
         return ChatMessageFindDto.listOf(chatMessageRepository.findMessageByChatRoomId(chatRoomId));
     }
 

--- a/src/main/java/goormcoder/webide/service/ChatMessageService.java
+++ b/src/main/java/goormcoder/webide/service/ChatMessageService.java
@@ -53,7 +53,7 @@ public class ChatMessageService {
 
     private void updateReadAt(ChatRoom chatRoom, Member sender, ChatMessage chatMessage) {
         ChatRoomMember chatRoomMember = chatRoomMemberRepository.findByChatRoomAndMember(chatRoom, sender);
-        chatRoomMember.setReadAt(chatMessage.getCreatedAt());
+        chatRoomMember.markAsRead(chatMessage.getCreatedAt());
     }
 
     public Optional<ChatMessage> getLastMessage(Long chatRoomId) {

--- a/src/main/java/goormcoder/webide/service/ChatMessageService.java
+++ b/src/main/java/goormcoder/webide/service/ChatMessageService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,7 +48,8 @@ public class ChatMessageService {
     public List<ChatMessageFindDto> getChatRoomMessages(Long chatRoomId, String loginId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.CHATROOM_NOT_FOUND.getMessage()));
-        chatRoomMemberService.checkChatRoomMember(chatRoom, loginId);
+        ChatRoomMember chatRoomMember = chatRoomMemberService.checkChatRoomMember(chatRoom, loginId);
+        chatRoomMember.markAsRead(LocalDateTime.now());
         return ChatMessageFindDto.listOf(chatMessageRepository.findMessageByChatRoomId(chatRoomId));
     }
 

--- a/src/main/java/goormcoder/webide/service/ChatRoomMemberService.java
+++ b/src/main/java/goormcoder/webide/service/ChatRoomMemberService.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ChatRoomMemberService {
 
-    public void checkChatRoomMember(ChatRoom chatRoom, String loginId) {
+    public ChatRoomMember checkChatRoomMember(ChatRoom chatRoom, String loginId) {
         Optional<ChatRoomMember> roomMember = chatRoom.getChatRoomMembers()
                 .stream()
                 .filter(member -> member.getMember().getLoginId().equals(loginId))
@@ -31,6 +31,8 @@ public class ChatRoomMemberService {
         } else if(isDeleted) {
             throw new EntityNotFoundException(ErrorMessages.CHATROOM_NOT_FOUND.getMessage());
         }
+
+        return roomMember.get();
     }
 
 }

--- a/src/main/java/goormcoder/webide/service/ChatRoomMemberService.java
+++ b/src/main/java/goormcoder/webide/service/ChatRoomMemberService.java
@@ -1,0 +1,23 @@
+package goormcoder.webide.service;
+
+import goormcoder.webide.constants.ErrorMessages;
+import goormcoder.webide.domain.ChatRoom;
+import goormcoder.webide.exception.ForbiddenException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomMemberService {
+
+    public void checkChatRoomMember(ChatRoom chatRoom, String loginId) {
+        boolean isMember = chatRoom.getChatRoomMembers()
+                .stream()
+                .anyMatch(member -> member.getMember().getLoginId().equals(loginId));
+
+        if (!isMember) {
+            throw new ForbiddenException(ErrorMessages.FORBIDDEN_CHATROOM_ACCESS);
+        }
+    }
+
+}

--- a/src/main/java/goormcoder/webide/service/ChatRoomService.java
+++ b/src/main/java/goormcoder/webide/service/ChatRoomService.java
@@ -86,12 +86,7 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.CHATROOM_NOT_FOUND.getMessage()));
 
-        chatRoomMemberService.checkChatRoomMember(chatRoom, loginId);
-
-        ChatRoomMember chatRoomMember = chatRoom.getChatRoomMembers().stream()
-                .filter(roomMember -> roomMember.getMember().getLoginId().equals(loginId))
-                .findFirst()
-                .orElseThrow(() -> new ForbiddenException(ErrorMessages.FORBIDDEN_CHATROOM_ACCESS));
+        ChatRoomMember chatRoomMember = chatRoomMemberService.checkChatRoomMember(chatRoom, loginId);
 
         chatRoomMember.markAsDeleted();
         chatRoomRepository.save(chatRoom);

--- a/src/main/java/goormcoder/webide/service/ChatRoomService.java
+++ b/src/main/java/goormcoder/webide/service/ChatRoomService.java
@@ -105,6 +105,7 @@ public class ChatRoomService {
 
         if(allMembersDeleted) {
             chatRoom.markAsDeleted();
+            chatRoom.deleteUniqueKey();
             chatRoomRepository.save(chatRoom);
         }
     }

--- a/src/main/java/goormcoder/webide/service/ChatRoomService.java
+++ b/src/main/java/goormcoder/webide/service/ChatRoomService.java
@@ -28,6 +28,7 @@ public class ChatRoomService {
     private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageService chatMessageService;
+    private final ChatRoomMemberService chatRoomMemberService;
 
     @Transactional
     public void createChatRoom(String loginId, ChatRoomCreateDto chatRoomCreateDto) {
@@ -84,6 +85,8 @@ public class ChatRoomService {
     public void deleteMyChatRoom(Long chatRoomId, String loginId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.CHATROOM_NOT_FOUND.getMessage()));
+
+        chatRoomMemberService.checkChatRoomMember(chatRoom, loginId);
 
         ChatRoomMember chatRoomMember = chatRoom.getChatRoomMembers().stream()
                 .filter(roomMember -> roomMember.getMember().getLoginId().equals(loginId))

--- a/src/main/java/goormcoder/webide/service/ChatRoomService.java
+++ b/src/main/java/goormcoder/webide/service/ChatRoomService.java
@@ -7,6 +7,7 @@ import goormcoder.webide.domain.Member;
 import goormcoder.webide.dto.request.ChatRoomCreateDto;
 import goormcoder.webide.dto.response.ChatMessageFindDto;
 import goormcoder.webide.dto.response.ChatRoomFindAllDto;
+import goormcoder.webide.dto.response.ChatRoomFindDto;
 import goormcoder.webide.dto.response.MessageSenderFindDto;
 import goormcoder.webide.exception.ForbiddenException;
 import goormcoder.webide.repository.ChatRoomRepository;
@@ -31,7 +32,7 @@ public class ChatRoomService {
     private final ChatRoomMemberService chatRoomMemberService;
 
     @Transactional
-    public void createChatRoom(String loginId, ChatRoomCreateDto chatRoomCreateDto) {
+    public ChatRoomFindDto createChatRoom(String loginId, ChatRoomCreateDto chatRoomCreateDto) {
         Member owner = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.MEMBER_NOT_FOUND.getMessage()));
         Member guest = memberRepository.findByLoginId(chatRoomCreateDto.invitedMemberLoginId())
@@ -57,6 +58,8 @@ public class ChatRoomService {
         chatRoom.addChatRoomMember(ChatRoomMember.of(guest, chatRoom));
 
         chatRoomRepository.save(chatRoom);
+
+        return ChatRoomFindDto.of(chatRoom);
     }
 
     @Transactional


### PR DESCRIPTION
## 📚개요
채팅방 삭제 로직 구현 및 채팅방 생성 응답 변경

## 💡Key Changes
- [WebSocket & STOMP]
  - [수신_에러] 오타 수정 /pub/queue/errors → **/sub/queue/errors**
- 채팅방 삭제 로직
  - ChatRoomMember Entity deletedAt 필드 추가
  - 사용자가 모두 채팅방을 삭제한 경우 ChatRoom에서 삭제
- 채팅방 생성 응답
  - 성공 메시지 → 생성된 채팅방 ID

## ✅To Reviewers
@suvven1 채팅방 생성 응답 변경했습니다 !
WebSocket 에러 메시지 수신 URL도 확인 부탁드립니다 !!!

## 🎓Reference
