### PR TITLE
feat: 배틀 풀이 제출 및 결과 확인 로직 구현

### DIFF
--- a/src/main/java/goormcoder/webide/constants/ErrorMessages.java
+++ b/src/main/java/goormcoder/webide/constants/ErrorMessages.java
@@ -15,6 +15,7 @@ public enum ErrorMessages {
     LIKE_NOT_FOUND("해당하는 좋아요가 존재하지 않습니다."),
     TESTCASE_NOT_FOUND("해당하는 테스트케이스가 존재하지 않습니다."),
     BATTLE_WAIT_NOT_FOUND("해당하는 대기방이 존재하지 않습니다."),
+    BATTLE_NOT_FOUND("해당하는 대결이 존재하지 않습니다."),
     SOLVE_NOT_FOUND("해당하는 제출이 존재하지 않습니다."),
     CHATROOM_NOT_FOUND("해당하는 채팅방이 존재하지 않습니다."),
     FRIEND_REQUEST_NOT_FOUND("해당하는 친구요청이 존재하지 않습니다."),

--- a/src/main/java/goormcoder/webide/controller/BattleController.java
+++ b/src/main/java/goormcoder/webide/controller/BattleController.java
@@ -1,10 +1,8 @@
 package goormcoder.webide.controller;
 
 import goormcoder.webide.dto.request.BattleWaitCreateDto;
-import goormcoder.webide.dto.response.BattleInfoDto;
-import goormcoder.webide.dto.response.BattleRecordFindAllDto;
-import goormcoder.webide.dto.response.BattleWaitFindDto;
-import goormcoder.webide.dto.response.BattleWaitSimpleDto;
+import goormcoder.webide.dto.request.SolveCreateDto;
+import goormcoder.webide.dto.response.*;
 import goormcoder.webide.jwt.PrincipalHandler;
 import goormcoder.webide.service.BattleService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,7 +43,11 @@ public class BattleController {
     }
 
     //풀이 제출 및 결과 확인
-
+    @PostMapping("/battles/submit/{battleId}/{questionId}")
+    @Operation(summary = "배틀 풀이 제출 및 결과 확인", description = "배틀 풀이를 제출하고, 결과(승패 여부)를 확인합니다.")
+    public ResponseEntity<BattleSubmitDto> submitSolution(@PathVariable Long battleId, @PathVariable Long questionId, @RequestBody SolveCreateDto solveCreateDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(battleService.submitSolution(principalHandler.getMemberLoginId(), battleId, questionId, solveCreateDto));
+    }
 
     //사용자 배틀 전적 조회
     @GetMapping("/battles/record")

--- a/src/main/java/goormcoder/webide/domain/Battle.java
+++ b/src/main/java/goormcoder/webide/domain/Battle.java
@@ -51,4 +51,8 @@ public class Battle extends BaseTimeEntity{
         this.winner = winner;
         this.question = question;
     }
+
+    public void saveWinner(Member member) {
+        this.winner = member;
+    }
 }

--- a/src/main/java/goormcoder/webide/domain/Member.java
+++ b/src/main/java/goormcoder/webide/domain/Member.java
@@ -105,4 +105,8 @@ public class Member {
     public void decrementPraiseScore() {
         this.praiseScore -= 5;
     }
+
+    public void incrementBattleScore() {
+        this.battleScore += 100;
+    }
 }

--- a/src/main/java/goormcoder/webide/dto/response/BattleSubmitDto.java
+++ b/src/main/java/goormcoder/webide/dto/response/BattleSubmitDto.java
@@ -1,0 +1,23 @@
+package goormcoder.webide.dto.response;
+
+import goormcoder.webide.domain.Battle;
+import goormcoder.webide.domain.Solve;
+import goormcoder.webide.domain.enumeration.SolveResult;
+
+public record BattleSubmitDto(
+        QuestionSummaryDto questionSummaryDto,
+        MemberSummaryDto memberSummaryDto,
+        SolveResult solveResult,
+        String solveResultMessage,
+        String battleResult
+) {
+    public static BattleSubmitDto of(Solve solve, String battleResult) {
+        return new BattleSubmitDto(
+                QuestionSummaryDto.of(solve.getQuestion()),
+                MemberSummaryDto.of(solve.getMember()),
+                solve.getSolveResult(),
+                solve.getSolveResult().getMessage(),
+                battleResult
+        );
+    }
+}

--- a/src/main/java/goormcoder/webide/repository/BattleSolveRepository.java
+++ b/src/main/java/goormcoder/webide/repository/BattleSolveRepository.java
@@ -1,0 +1,7 @@
+package goormcoder.webide.repository;
+
+import goormcoder.webide.domain.BattleSolve;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BattleSolveRepository extends JpaRepository<BattleSolve, Long> {
+}

--- a/src/main/java/goormcoder/webide/service/BattleService.java
+++ b/src/main/java/goormcoder/webide/service/BattleService.java
@@ -1,21 +1,14 @@
 package goormcoder.webide.service;
 
 import goormcoder.webide.constants.ErrorMessages;
-import goormcoder.webide.domain.Battle;
-import goormcoder.webide.domain.BattleWait;
-import goormcoder.webide.domain.Member;
-import goormcoder.webide.domain.Question;
+import goormcoder.webide.domain.*;
+import goormcoder.webide.domain.enumeration.SolveResult;
 import goormcoder.webide.dto.request.BattleWaitCreateDto;
-import goormcoder.webide.dto.response.BattleInfoDto;
-import goormcoder.webide.dto.response.BattleRecordFindAllDto;
-import goormcoder.webide.dto.response.BattleWaitFindDto;
-import goormcoder.webide.dto.response.BattleWaitSimpleDto;
+import goormcoder.webide.dto.request.SolveCreateDto;
+import goormcoder.webide.dto.response.*;
 import goormcoder.webide.exception.ConflictException;
 import goormcoder.webide.exception.ForbiddenException;
-import goormcoder.webide.repository.BattleRepository;
-import goormcoder.webide.repository.BattleWaitRepository;
-import goormcoder.webide.repository.MemberRepository;
-import goormcoder.webide.repository.QuestionRepository;
+import goormcoder.webide.repository.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -33,6 +26,10 @@ public class BattleService {
     private final MemberRepository memberRepository;
     private final QuestionRepository questionRepository;
     private final BattleRepository battleRepository;
+    private final QuestionService questionService;
+    private final MemberService memberService;
+    private final SolveService solveService;
+    private final BattleSolveRepository battleSolveRepository;
 
     //대기방 등록
     @Transactional
@@ -63,7 +60,7 @@ public class BattleService {
     //대기방 조회
     @Transactional(readOnly = true)
     public BattleWaitFindDto findBattleWait(String memberLoginId, Long roomId) {
-        BattleWait battleWait = findByIdOrThrow(roomId);
+        BattleWait battleWait = findByRoomIdOrThrow(roomId);
 
         Member member = memberRepository.findByLoginIdOrThrow(memberLoginId);
 
@@ -75,7 +72,7 @@ public class BattleService {
     //배틀 시작
     @Transactional
     public BattleInfoDto startBattle(String memberLoginId, Long roomId) {
-        BattleWait battleWait = findByIdOrThrow(roomId);
+        BattleWait battleWait = findByRoomIdOrThrow(roomId);
 
         Member member = memberRepository.findByLoginIdOrThrow(memberLoginId);
 
@@ -100,15 +97,32 @@ public class BattleService {
         return BattleInfoDto.of(battle, battle.getQuestion());
     }
 
-    public BattleWait findByIdOrThrow(Long roomId) {
-        return battleWaitRepository.findById(roomId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.BATTLE_WAIT_NOT_FOUND.getMessage()));
-    }
+    //풀이 제출 및 결과 확인
+    @Transactional
+    public BattleSubmitDto submitSolution(String memberLoginId, Long battleId, Long questionId, SolveCreateDto solveCreateDto) {
+        Question question = questionService.findById(questionId);
+        Member member = memberService.findByLoginId(memberLoginId);
 
-    private void validateMemberAccessToBattleWait(Member member, BattleWait battleWait) {
-        if (!member.getId().equals(battleWait.getGivenMember().getId()) &&
-                (battleWait.getReceivedMember() == null || !member.getId().equals(battleWait.getReceivedMember().getId()))) {
-            throw new ForbiddenException(ErrorMessages.FORBIDDEN_ACCESS);
+        //풀이 생성 로직 호출
+        Solve solve = solveService.create(question, member, solveCreateDto);
+
+        Battle battle = findByIdOrThrow(battleId);
+
+        //대결 풀이 연결
+        battleSolveRepository.save(BattleSolve.of(battle, solve));
+
+        //정답 확인
+        if (solve.getSolveResult() == SolveResult.CORRECT) {
+            // 대결 결과 저장 및 승자 판별
+            if (battle.getWinner() == null) {
+                battle.saveWinner(solve.getMember());
+                member.incrementBattleScore();
+                return BattleSubmitDto.of(solve, "배틀에서 승리했습니다!");
+            } else {
+                return BattleSubmitDto.of(solve, "배틀에서 패배했습니다. 상대방이 먼저 문제를 맞췄습니다.");
+            }
+        } else {
+            return BattleSubmitDto.of(solve, null);
         }
     }
 
@@ -129,5 +143,22 @@ public class BattleService {
         List<Battle> battles = battleRepository.findByMember(member, PageRequest.of(0, 5));
 
         return BattleRecordFindAllDto.of(member, battles, totalResult, winRateStr);
+    }
+
+    public BattleWait findByRoomIdOrThrow(Long roomId) {
+        return battleWaitRepository.findById(roomId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.BATTLE_WAIT_NOT_FOUND.getMessage()));
+    }
+
+    private void validateMemberAccessToBattleWait(Member member, BattleWait battleWait) {
+        if (!member.getId().equals(battleWait.getGivenMember().getId()) &&
+                (battleWait.getReceivedMember() == null || !member.getId().equals(battleWait.getReceivedMember().getId()))) {
+            throw new ForbiddenException(ErrorMessages.FORBIDDEN_ACCESS);
+        }
+    }
+
+    public Battle findByIdOrThrow(Long battleId) {
+        return battleRepository.findById(battleId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.BATTLE_NOT_FOUND.getMessage()));
     }
 }


### PR DESCRIPTION
## 📚개요
배틀 풀이 제출 및 결과 확인 로직 구현

## 💡Key Changes
1. 먼저 풀이 제출 시 '정답' -> "배틀에서 승리했습니다!"
2. 풀이 제출 시 '정답' 이지만 이미 상대방이 먼저 '정답'인 풀이를 제출한 경우 -> "배틀에서 패배했습니다. 상대방이 먼저 문제를 맞췄습니다."
3. 풀이 제출 시 '오답'인 경우 -> 무슨 오답인지 알려준 후 계속 풀이를 진행할 수 있도록

## ✅To Reviewers

## 🎓Reference
