### PR TITLE
feat: 배틀 취소 및 대기방 삭제 로직 구현

### DIFF
--- a/src/main/java/goormcoder/webide/constants/ErrorMessages.java
+++ b/src/main/java/goormcoder/webide/constants/ErrorMessages.java
@@ -26,6 +26,7 @@ public enum ErrorMessages {
     //409 CONFLICT
     LIKE_CONFLICT("이미 좋아요를 누르셨습니다."),
     BATTLE_MEMBER_CONFLICT("같은 사용자가 두 명의 역할을 맡을 수 없습니다."),
+    BATTLE_CANCEL_CONFLICT("이미 배틀이 시작되어 취소할 수 없습니다."),
     CHATROOM_CONFLICT("해당 사용자와의 채팅방이 이미 존재합니다."),
 
     //401 UNAUTHORIZED

--- a/src/main/java/goormcoder/webide/controller/BattleController.java
+++ b/src/main/java/goormcoder/webide/controller/BattleController.java
@@ -35,6 +35,14 @@ public class BattleController {
         return ResponseEntity.status(HttpStatus.OK).body(battleService.findBattleWait(principalHandler.getMemberLoginId(), roomId));
     }
 
+    //대기방 취소
+    @PostMapping("/battles/cancel/{roomId}")
+    @Operation(summary = "배틀 대기방 취소", description = "매칭 되지 않을 시 랜덤 매칭 버튼을 한 번 더 누르면 배틀 대기가 취소됩니다.")
+    public ResponseEntity<String> cancelBattleWait(@PathVariable Long roomId) {
+        battleService.cancelBattleWait(principalHandler.getMemberLoginId(), roomId);
+        return ResponseEntity.status(HttpStatus.OK).body("배틀 취소 및 대기방이 삭제되었습니다.");
+    }
+
     //배틀 시작
     @PostMapping("/battles/start/{roomId}")
     @Operation(summary = "배틀 시작", description = "대결할 회원이 다 모였으면 대결을 시작합니다.")

--- a/src/main/java/goormcoder/webide/service/BattleService.java
+++ b/src/main/java/goormcoder/webide/service/BattleService.java
@@ -69,6 +69,23 @@ public class BattleService {
         return BattleWaitFindDto.of(battleWait.getId(), battleWait.getGivenMember(), battleWait.getReceivedMember(), battleWait.isFull());
     }
 
+    //배틀 취소 및 대기방 삭제
+    @Transactional(readOnly = true)
+    public void cancelBattleWait(String memberLoginId, Long roomId) {
+        Member member = memberRepository.findByLoginIdOrThrow(memberLoginId);
+        BattleWait battleWait = findByRoomIdOrThrow(roomId);
+
+        //사용자 권한 검증
+        validateMemberAccessToBattleWait(member, battleWait);
+
+        //대기방 상태 검증
+        if (battleWait.isFull()) {
+            throw new ConflictException(ErrorMessages.BATTLE_CANCEL_CONFLICT);
+        }
+
+        battleWait.markAsDeleted();
+    }
+
     //배틀 시작
     @Transactional
     public BattleInfoDto startBattle(String memberLoginId, Long roomId) {


### PR DESCRIPTION
## 📚개요
배틀 취소 및 대기방 삭제 로직 구현

## 💡Key Changes
배틀 취소 및 대기방 삭제 로직 구현

- 매칭이 되지 않았을 때 랜덤 매칭 버튼을 한 번 더 누르면 매칭이 취소 및 대기방 삭제될 수 있도록 구현하였습니다.

## ✅To Reviewers

## 🎓Reference
