### PR TITLE
fix : 대결 대기방 취소 readOnly 삭제

### DIFF
--- a/src/main/java/goormcoder/webide/service/BattleService.java
+++ b/src/main/java/goormcoder/webide/service/BattleService.java
@@ -70,7 +70,7 @@ public class BattleService {
     }
 
     //배틀 취소 및 대기방 삭제
-    @Transactional(readOnly = true)
+    @Transactional
     public void cancelBattleWait(String memberLoginId, Long roomId) {
         Member member = memberRepository.findByLoginIdOrThrow(memberLoginId);
         BattleWait battleWait = findByRoomIdOrThrow(roomId);


### PR DESCRIPTION
## 📚개요
fix : 대결 대기방 취소 readOnly 삭제
## 💡Key Changes
- readOnly=true 때문에 deleted_at 업데이트 불가하여 삭제

## ✅To Reviewers

## 🎓Reference
