### PR TITLE
fix : 대결 대기방 조회 쿼리 수정

### DIFF
--- a/src/main/java/goormcoder/webide/repository/BattleWaitRepository.java
+++ b/src/main/java/goormcoder/webide/repository/BattleWaitRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface BattleWaitRepository extends JpaRepository<BattleWait, Long> {
 
     @Query("select bw from BattleWait bw " +
-            "where bw.level = :level and bw.language = :language and bw.isFull = false " +
+            "where bw.level = :level and bw.language = :language and bw.isFull = false and bw.deletedAt IS NULL " +
             "order by bw.createdAt asc")
     List<BattleWait> findByLevelAndLanguage(
             @Param("level") Integer level,


### PR DESCRIPTION

## 📚개요
fix : 대결 대기방 조회 쿼리 수정
## 💡Key Changes
- deleted_at 이 null인 대기방만 조회하게 수정
- 위 수정으로 삭제된 대기방이여도 아이디 난이도 언어가 같으면 중복 에러 반환되는 현상 해결 완료
## ✅To Reviewers

## 🎓Reference
