### PR TITLE
feat: WebSocket 인증 로직 구현

### DIFF
--- a/src/main/java/goormcoder/webide/config/WebSocketConfig.java
+++ b/src/main/java/goormcoder/webide/config/WebSocketConfig.java
@@ -1,14 +1,28 @@
 package goormcoder.webide.config;
 
+import goormcoder.webide.util.interceptor.CustomHandshakeInterceptor;
+import goormcoder.webide.util.interceptor.WebSocketAuthChannelInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketAuthChannelInterceptor webSocketAuthChannelInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -19,7 +33,19 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*");
+                .setAllowedOriginPatterns("*")
+                .setHandshakeHandler(new DefaultHandshakeHandler() {
+                    @Override
+                    protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler, Map<String, Object> attributes) {
+                        return new UsernamePasswordAuthenticationToken(attributes.get("loginId"), null);
+                    }
+                })
+                .addInterceptors(new CustomHandshakeInterceptor());
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketAuthChannelInterceptor);
     }
 
 }

--- a/src/main/java/goormcoder/webide/controller/ChatController.java
+++ b/src/main/java/goormcoder/webide/controller/ChatController.java
@@ -17,10 +17,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.List;
+import java.util.Objects;
 
 @RestController
 @Tag(name = "Chat", description = "1:1 채팅 관련 API")
@@ -35,8 +39,9 @@ public class ChatController {
 
     // Web Socket Connection URL - ws://localhost:8080/ws
     @MessageMapping("/send")
-    public void sendMessage(@Payload ChatMessageSendDto chatMessageSendDto) {
-        ChatMessage savedMessage = chatMessageService.saveMessage(chatMessageSendDto);
+    public void sendMessage(@Payload ChatMessageSendDto chatMessageSendDto, SimpMessageHeaderAccessor headerAccessor) {
+        String loginId = Objects.requireNonNull(headerAccessor.getUser()).getName();
+        ChatMessage savedMessage = chatMessageService.saveMessage(chatMessageSendDto, loginId);
         messagingTemplate.convertAndSend(
                 "/sub/chats/room/" + savedMessage.getChatRoom().getId(),
                 ChatMessageFindDto.of(savedMessage)

--- a/src/main/java/goormcoder/webide/dto/request/ChatMessageSendDto.java
+++ b/src/main/java/goormcoder/webide/dto/request/ChatMessageSendDto.java
@@ -8,9 +8,6 @@ public record ChatMessageSendDto(
         @NotNull(message = ChatConstants.CHATROOM_ID_IS_NULL)
         Long chatRoomId,
 
-        // Web Socket 테스트용 필드 - 추후 삭제 예정
-        String senderLoginId,
-
         @NotNull(message = ChatConstants.MESSAGE_IS_NULL)
         String message
 

--- a/src/main/java/goormcoder/webide/service/ChatMessageService.java
+++ b/src/main/java/goormcoder/webide/service/ChatMessageService.java
@@ -29,10 +29,11 @@ public class ChatMessageService {
     private final ChatRoomMemberService chatRoomMemberService;
 
     @Transactional
-    public ChatMessage saveMessage(ChatMessageSendDto chatMessageSendDto) {
+    public ChatMessage saveMessage(ChatMessageSendDto chatMessageSendDto, String loginId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatMessageSendDto.chatRoomId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.CHATROOM_NOT_FOUND.getMessage()));
-        Member sender = memberService.findByLoginId(chatMessageSendDto.senderLoginId());
+        Member sender = memberService.findByLoginId(loginId);
+        chatRoomMemberService.checkChatRoomMember(chatRoom, loginId);
 
         ChatMessage chatMessage = ChatMessage.of(chatMessageSendDto.message(), sender, chatRoom);
         chatRoom.addChatMessage(chatMessage);

--- a/src/main/java/goormcoder/webide/util/interceptor/CustomHandshakeInterceptor.java
+++ b/src/main/java/goormcoder/webide/util/interceptor/CustomHandshakeInterceptor.java
@@ -1,0 +1,28 @@
+package goormcoder.webide.util.interceptor;
+
+import goormcoder.webide.constants.ErrorMessages;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+public class CustomHandshakeInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        if(request.getPrincipal() == null) {
+            throw new AccessDeniedException(ErrorMessages.JWT_UNAUTHORIZED_EXCEPTION.getMessage());
+        }
+
+        String loginId = request.getPrincipal().getName();
+        attributes.put("loginId", loginId);
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/src/main/java/goormcoder/webide/util/interceptor/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/goormcoder/webide/util/interceptor/WebSocketAuthChannelInterceptor.java
@@ -1,0 +1,59 @@
+package goormcoder.webide.util.interceptor;
+
+
+import goormcoder.webide.domain.Member;
+import goormcoder.webide.domain.enumeration.MemberRole;
+import goormcoder.webide.jwt.JwtProvider;
+import goormcoder.webide.jwt.JwtValidation;
+import goormcoder.webide.security.MemberDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        if(StompCommand.CONNECT.equals(accessor.getCommand()) || StompCommand.SEND.equals(accessor.getCommand())) {
+            List<String> authorization = accessor.getNativeHeader("Authorization");
+            if(authorization != null && !authorization.isEmpty()) {
+                String token = authorization.get(0).split(" ")[1];
+                if(isValidToken(token)) {
+                    setAuthenticationContext(token);
+                }
+            }
+        }
+
+        return message;
+    }
+
+    private boolean isValidToken(String token) {
+        return jwtProvider.validateToken(token) == JwtValidation.JWT_VALID;
+    }
+
+    private void setAuthenticationContext(String token) {
+        Member data = Member.builder()
+                .loginId(jwtProvider.getUsername(token))
+                .password("password")
+                .role(MemberRole.valueOf(jwtProvider.getRole(token).toUpperCase()))
+                .build();
+
+        MemberDetails memberDetails = new MemberDetails(data);
+        Authentication authToken = new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+}


### PR DESCRIPTION
## 📚개요
WebSocket 인증 로직 구현

## 💡Key Changes
- WebSocket 인증
  - 연결 및 전송 시 엑세스 토큰 확인
- 메시지 전송 요청 변경
  - ChatMessageSendDto SenderLoginId 삭제
  - 메시지 헤더에서 사용자 아이디 추출하여 사용

## ✅To Reviewers
SecurityConfig 화이트 리스트에 `/ws/**` 그대로 넣고 사용하시면 됩니다 !

## 🎓Reference
